### PR TITLE
Fix graph rendering for Python 3 and NetworkX 2.x

### DIFF
--- a/e3fp_paper/sea_utils/library.py
+++ b/e3fp_paper/sea_utils/library.py
@@ -35,25 +35,25 @@ def fit_wizard_auto(modelfile, library, tc_range, dists=None, testing=False,
     dist_file = "{0}-distfit.png".format(lib_name)
     if not testing and not no_plot:
         plotfile = os.path.join(lib_dir, dist_file)
-        print "plot dists"
+        print("plot dists")
         plot_dists(dists, plotfile)
     suggested = suggested_cutoff(dists)
-    print "\nDistribution quality plot shown in browser window."
-    print "\tSuggested cutoff from simplistic ratio analysis: %g" % suggested
+    print("\nDistribution quality plot shown in browser window.")
+    print("\tSuggested cutoff from simplistic ratio analysis: %g" % suggested)
     if testing:
         cutoff = 0.28
     else:
-        print "\tAutomatically picking cutoff as: %g." % suggested
+        print("\tAutomatically picking cutoff as: %g." % suggested)
         val = suggested
         val = round_cutoff(val)
         try:
             dists[val]
         except KeyError:
-            print "No data for that cutoff. Continuing anyways."
+            print("No data for that cutoff. Continuing anyways.")
         cutoff = val
     fit = dists[cutoff][1]
     save_fit(library, cutoff, fit)
-    print "Fit saved to library file!"
+    print("Fit saved to library file!")
 
 
 def library_fit(library_file, yes=False, testing=False, plot_prefix=None,

--- a/project/analysis/visualization/draw_graph.py
+++ b/project/analysis/visualization/draw_graph.py
@@ -88,8 +88,7 @@ if __name__ == "__main__":
                    rank="same")
 
     for link in tree["links"]:
-        G.add_edge(tree["nodes"][link["source"]]["id"],
-                   tree["nodes"][link["target"]]["id"], **edge_attributes)
+        G.add_edge(link["source"], link["target"], **edge_attributes)
 
     G.layout(args="-Goverlap=false")
     G.draw(os.path.join(mol_figs_dir, 'graph.png'), prog='dot')

--- a/project/analysis/visualization/make_shell_figures.py
+++ b/project/analysis/visualization/make_shell_figures.py
@@ -619,8 +619,8 @@ if __name__ == "__main__":
             node_order[node] = None
     nx.set_node_attributes(out_graph, name='order', values=node_order)
 
-    json_graph = json_graph.node_link_data(out_graph)
+    out_json_graph = json_graph.node_link_data(out_graph)
 
     with open(json_out_file, "w") as f:
-        f.write(json.dumps(json_graph, sort_keys=False, indent=4,
+        f.write(json.dumps(out_json_graph, sort_keys=False, indent=4,
                            separators=(',', ': ')))

--- a/project/analysis/visualization/make_shell_figures.py
+++ b/project/analysis/visualization/make_shell_figures.py
@@ -119,7 +119,7 @@ def create_shell_graph(fp, radius_multiplier=RADIUS_MULTIPLIER,
     shell_level = {signed_to_unsigned_int(k.identifier): int(
                        round(k.radius / radius_multiplier))
                    for k in shells_to_examine}
-    shell_atom = {signed_to_unsigned_int(k.identifier): k.center_atom
+    shell_atom = {signed_to_unsigned_int(k.identifier): int(k.center_atom)
                   for k in shells_to_examine}
     shell_to_substruct_map = {}
     G = nx.DiGraph()  # create an empty graph
@@ -145,7 +145,7 @@ def create_shell_graph(fp, radius_multiplier=RADIUS_MULTIPLIER,
             shells_to_examine.add(last_shell)
             shell_level[last_shell.identifier] = (
                 shell_level[shell.identifier] - 1)
-            shell_atom[last_shell.identifier] = last_shell.center_atom
+            shell_atom[last_shell.identifier] = int(last_shell.center_atom)
             G.add_edge(last_shell.identifier, shell.identifier)
             print("added edge between {} and {}".format(
                 last_shell.identifier, shell.identifier))
@@ -155,7 +155,7 @@ def create_shell_graph(fp, radius_multiplier=RADIUS_MULTIPLIER,
                 s = s.duplicate
             s.identifier = signed_to_unsigned_int(s.identifier)
             shell_level[s.identifier] = shell_level[shell.identifier] - 1
-            shell_atom[s.identifier] = s.center_atom
+            shell_atom[s.identifier] = int(s.center_atom)
             G.add_edge(s.identifier, shell.identifier)
             print("added edge between {} and {}".format(s.identifier,
                                                         shell.identifier))
@@ -220,7 +220,7 @@ def get_cgo_arc_obj(center, norm, start, radians, linespacing=0.,
     start2 = np.dot(rot1, start_ref.reshape(3, 1)).T
     rot2 = make_rotation_matrix(start2, np.array([1., 0., 0.]))
     inv_rot = np.dot(rot2, rot1).T
-    angles = np.linspace(0., radians, float(radians) / res)
+    angles = np.linspace(0., radians, int(float(radians) / res))
     ref_xyz = np.empty((angles.shape[0], 3), dtype=np.double)
     ref_xyz[:, 0] = rad * np.cos(angles)
     ref_xyz[:, 1] = rad * np.sin(angles)
@@ -406,7 +406,7 @@ def define_colors_by_atom_types(d, mol, cycle=COLOR_ALPHABET,
     atom_colors = {}
     for i, (identifier, atoms) in enumerate(
             sorted(d.items(), key=lambda x: (-len(x[1]), x[0]))):
-        elem = mol.GetAtomWithIdx(list(atoms)[0]).GetSymbol()
+        elem = mol.GetAtomWithIdx(int(list(atoms)[0])).GetSymbol()
         cpk = elem_colors.get(elem, (0, 0, 0))
         rgb = sorted([(x, int(10 * compute_yuv_dist(cpk, x)) * .1, j)
                       for j, x in enumerate(colors)

--- a/project/analysis/visualization/make_shell_figures.py
+++ b/project/analysis/visualization/make_shell_figures.py
@@ -160,9 +160,9 @@ def create_shell_graph(fp, radius_multiplier=RADIUS_MULTIPLIER,
             print("added edge between {} and {}".format(s.identifier,
                                                         shell.identifier))
         shell_to_node_map[shell] = None
-    nx.set_node_attributes(G, 'shell', identifier_to_shell)
-    nx.set_node_attributes(G, 'level', shell_level)
-    nx.set_node_attributes(G, 'atom_id', shell_atom)
+    nx.set_node_attributes(G, name='shell', values=identifier_to_shell)
+    nx.set_node_attributes(G, name='level', values=shell_level)
+    nx.set_node_attributes(G, name='atom_id', values=shell_atom)
     return G
 
 
@@ -379,13 +379,13 @@ def pymol_load_with_defaults(pdb_file=None, stick_radius=.1, sphere_scale=.15):
 
 def get_atom_types(mol, graph):
     logging.info("Get atom types of nodes.")
-    root = nx.topological_sort(graph)[0]
+    root = next(nx.topological_sort(graph))
     assert(root == ROOT_NODE_NAME)
     atom_nodes = sorted(graph[root].keys())
     atom_types_dict = {}
     for node in atom_nodes:
         atom_types_dict[node] = set([x.center_atom for x
-                                    in graph.node[node]["shell"]])
+                                    in graph.nodes[node]["shell"]])
     return atom_types_dict
 
 
@@ -507,12 +507,12 @@ def save_shell_figures(mol_pdb_file, shell_pdb_files, graph, atom_colors,
         identifier = int(os.path.basename(pdb_file).split('.')[0])
         shell_image_file = os.path.join(
             out_dir, "{}_shell.png".format(identifier))
-        graph.node[identifier]["image"] = shell_image_file
+        graph.nodes[identifier]["image"] = shell_image_file
         if not overwrite and os.path.isfile(shell_image_file):
             continue
         cmd.reinitialize()
         pymol_load_with_defaults(pdb_file)
-        shell = list(graph.node[identifier]["shell"])[0]
+        shell = list(graph.nodes[identifier]["shell"])[0]
         radius = shell.radius
         if radius > 0:
             radii.add(radius)
@@ -611,13 +611,13 @@ if __name__ == "__main__":
     node_order = {}
     left_to_right_atom_ids = list(left_to_right_atom_ids)
     for node in out_graph:
-        del(out_graph.node[node]["shell"])
-        if out_graph.node[node]["level"] == 0:
+        del(out_graph.nodes[node]["shell"])
+        if out_graph.nodes[node]["level"] == 0:
             node_order[node] = left_to_right_atom_ids.index(
-                out_graph.node[node]["atom_id"])
+                out_graph.nodes[node]["atom_id"])
         else:
             node_order[node] = None
-    nx.set_node_attributes(out_graph, 'order', node_order)
+    nx.set_node_attributes(out_graph, name='order', values=node_order)
 
     json_graph = json_graph.node_link_data(out_graph)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [
     'networkx>=1.11',
     'nolearn>=0.6.0',
     'pandas>=0.18.1',
-    'pygraphviz==1.3.1',
+    'pygraphviz>=1.3.1',
     'scikit-learn>=0.18.0',
     'seaborn>=0.7.1'
 ]


### PR DESCRIPTION
This PR makes a few fixes to make the package more Python 3-compatible and to use NetworkX's 2.x API.
It resolves errors raised in https://github.com/keiserlab/e3fp/issues/48.

@VirtualChemist, can you confirm that graph rendering works for you with this fix?